### PR TITLE
More prominent "Admin" link + small layout tweaks and fixes

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -38,7 +38,7 @@ a:hover {
 }
 
 #main {
-  height: 400px;
+  height: 424px;
   text-align: center;
 }
 
@@ -48,11 +48,11 @@ a:hover {
   -moz-box-shadow:    0px 0px 5px 1px rgba(0, 0, 0, 0.1);
   -webkit-box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.1);
   box-shadow:         0px 0px 5px 1px rgba(0, 0, 0, 0.1);
-  margin-bottom: 20px;
+  margin-bottom: 30px;
 }
 
 #main h1 {
-  margin: 30px 0;
+  margin: 30px 0 20px 0;
 }
 
 #main h1, #main p {
@@ -60,9 +60,17 @@ a:hover {
   margin-right: 15px;
 }
 
+#main h3 {
+  margin: 3.5px 0;
+}
+
 #main p {
   font-size: 11px;
   line-height: 2;
+}
+
+#main a {
+  font-weight: bold;
 }
 
 #logo {
@@ -78,6 +86,7 @@ a:hover {
 
 div.header {
   height: 130px;
+  padding-bottom: 15px;
 }
 
 div.header h1, div.header p {
@@ -144,7 +153,7 @@ li.repo {
 li.repo > a {
   display: block;
   width: 100%;
-  height: 100%;
+  height: 90%;
   overflow: hidden;
   text-decoration: none;
   color: inherit;
@@ -170,6 +179,14 @@ li.repo h3 {
   margin-top: 2px;
   margin-bottom: 15px;
   color: #999;
+}
+
+li.repo span.watchers {
+  margin-left: 7.5px;
+}
+
+li.repo span.bullet {
+  margin: 0 3.25px;
 }
 
 .repo:after {

--- a/index.html
+++ b/index.html
@@ -170,13 +170,13 @@
       <div id="main" class="grid-1">
         <img src="assets/logo-small.png" alt="F# Community Space" />
         <h1>The F# Community Space for incubating open community projects.</h1>
-        
-
+        <h3><a href="https://github.com/fsprojects/FsProjectsAdmin/">What is fsprojects?</a></h3>
+        <h3><a href="https://github.com/fsprojects/">fsprojects on GitHub</a></h3>
       </div>
 
       <div class="grid grid-3">
         <div id="statistics" class="grid-1 alpha header">
-          <h1><a href="https://github.com/fsprojects/FsProjectsAdmin/">Admin</a> and Statistics</h1>
+          <h1>Admin and Statistics</h1>
           <p>
             <a href="https://github.com/fsprojects/FsProjectsAdmin/">Post an issue to add or remove a project</a>.
             <a href="http://fsharp.org/community/projects/">List your project on fsharp.org</a>.


### PR DESCRIPTION
When I was searching for fsprojects policies / intentions / mission statemente, etc., I saw the "Admin" link, but never ever clicked on it, since I understood "Admin" in a way like "It's a link for administrators" and not "a link for administrative concerns in general". Maybe this PR helps others who might experience the same issue.

----------------------------------------------------------------------
Changes:

* Clarified intention of the "admin" link and moved it
* Added link to GitHub
* Layout changes (moved stars / watchers links in project box)
* Layout fix (use the space directly underneeth 'main')
* Small layout changes (optical)